### PR TITLE
Dependency updates (#397)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,11 @@ repositories {
 
 dependencies {
     // discord/jda related
-    implementation('net.dv8tion:JDA:4.3.0_298') {
+    implementation('net.dv8tion:JDA:4.3.0_306') {
         exclude group: 'club.minnced', module: 'opus-java'
     }
     implementation 'com.jagrosh:jda-utilities:3.0.5'
-    implementation 'club.minnced:discord-webhooks:0.5.7'
+    implementation 'club.minnced:discord-webhooks:0.5.8'
     implementation 'dev.mlnr:BotListHandler-jda:2.0.0_8'
 
     // audio
@@ -38,7 +38,7 @@ dependencies {
     jooqGenerator 'org.postgresql:postgresql:42.2.23'
 
     // logging
-    implementation 'ch.qos.logback:logback-classic:1.3.0-alpha5'
+    implementation 'ch.qos.logback:logback-classic:1.3.0-alpha6'
     implementation 'io.sentry:sentry-logback:5.0.1'
 
     // eval
@@ -56,7 +56,7 @@ dependencies {
 
     // other
     implementation 'io.javalin:javalin:3.13.10'
-    implementation 'io.github.classgraph:classgraph:4.8.110'
+    implementation 'io.github.classgraph:classgraph:4.8.111'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.0.3'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
 }


### PR DESCRIPTION
* Bump JDA from 4.3.0_298 to 4.3.0_299

* Bump logback-classic from 1.3.0-alpha5 to 1.3.0-alpha6

* Bump discord-webhooks from 0.5.7 to 0.5.8

* Bump JDA from 4.3.0_299 to 4.3.0_300

* Bump JDA from 4.3.0_300 to 4.3.0_301

* Bump JDA from 4.3.0_301 to 4.3.0_303

* Bump JDA from 4.3.0_303 to 4.3.0_304

* Bump classgraph from 4.8.110 to 4.8.111

* Bump JDA from 4.3.0_304 to 4.3.0_305

* Bump JDA from 4.3.0_305 to 4.3.0_306

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>